### PR TITLE
use bit operations to lightup bit counter diodes

### DIFF
--- a/examples/2_bit_counter/2_bit_counter.rb
+++ b/examples/2_bit_counter/2_bit_counter.rb
@@ -10,13 +10,12 @@ pin27.off
 sum = 0
 
 PiPiper.watch :pin => 22, :trigger => :rising do |pin|
-  sum = sum + 1
-  display = sum % 4
+  sum += 1
   puts sum 
 
-  pin17.update_value(display == 2 || display == 3)
-  pin27.update_value(display == 1 || display == 3)
+  # get single bits of sum
+  pin17.update_value(sum & 0b01 == 0b01) 
+  pin27.update_value(sum & 0b10 == 0b10)
 end
 
 PiPiper.wait
-


### PR DESCRIPTION
I fiddled around with the bitcounter example and found an approach that is easily extensible for 3 or more bits, by checking for single bits in the current sum to lightup the according diode.
