### PR TITLE
Implements pull up/pull down support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ PiPiper.wait
 
 Your block will be called when a change to the pin's state is detected.
 
+When using pins as input, you can use internal resistors to pull the pin 
+up or pull down. This is important if you use open-collector sensors
+which have floating output in some states.
+
+You can set resistors when creating a pin passing a :pull parameter
+(which can be :up, :down or :off, which is the default).
+
+pin = PiPiper::Pin.new(:pin => 17, :direction => :in, :pull => :up)
+
+This way, the pin will always return 'on' if it is unconnected or of the
+sensor has an open collector output.
+
+You can later alter the pulling resistors using PiPiper#pull!
+
 Additionally you can use pins as output too:
 
 ```ruby

--- a/Rakefile
+++ b/Rakefile
@@ -1,14 +1,19 @@
-require 'rubygems'  
-require 'rake'  
-require 'echoe'  
-  
-Echoe.new('pi_piper', '1.3.1') do |p|  
-  p.description     = "Event driven Raspberry Pi GPIO library"  
-  p.url             = "http://github.com/jwhitehorn/pi_piper"  
-  p.author          = "Jason Whitehorn"  
-  p.email           = "jason.whitehorn@gmail.com"  
-  p.ignore_pattern  = ["examples/**/*"]  
-  p.dependencies = ['ffi']  
-end  
-  
-Dir["#{File.dirname(__FILE__)}/tasks/*.rake"].sort.each { |ext| load ext }  
+require 'rubygems'
+require 'rake'
+require 'echoe'
+require 'rake/testtask'
+
+Echoe.new('pi_piper', '1.3.1') do |p|
+  p.description     = "Event driven Raspberry Pi GPIO library"
+  p.url             = "http://github.com/jwhitehorn/pi_piper"
+  p.author          = "Jason Whitehorn"
+  p.email           = "jason.whitehorn@gmail.com"
+  p.ignore_pattern  = ["examples/**/*", "spec/**/*"]
+  p.dependencies    = ['ffi']
+end
+
+Dir["#{File.dirname(__FILE__)}/tasks/*.rake"].sort.each { |ext| load ext }
+
+Rake::TestTask.new do |t|
+    t.pattern = 'spec/**/*_spec.rb'
+end

--- a/lib/pi_piper/bcm2835.rb
+++ b/lib/pi_piper/bcm2835.rb
@@ -25,6 +25,7 @@ module PiPiper
     attach_function :spi_set_data_mode, :bcm2835_spi_setDataMode,    [:uint8], :void
     attach_function :spi_chip_select_polarity, 
                     :bcm2835_spi_setChipSelectPolarity,              [:uint8, :uint8], :void
+    attach_function :pin_set_pud,         :bcm2835_gpio_set_pud,     [:uint8, :uint8], :void
 
     def self.spi_transfer_bytes(data)
       data_out = FFI::MemoryPointer.new(data.count) 

--- a/pi_piper.gemspec
+++ b/pi_piper.gemspec
@@ -18,6 +18,9 @@ Gem::Specification.new do |s|
   s.rubygems_version = "2.0.0"
   s.summary = "Event driven Raspberry Pi GPIO library"
 
+  s.add_development_dependency(%q<rake>, [">= 0"])
+  s.add_development_dependency(%q<echoe>, [">= 0"])
+
   if s.respond_to? :specification_version then
     s.specification_version = 4
 

--- a/spec/pull_mode_spec.rb
+++ b/spec/pull_mode_spec.rb
@@ -1,0 +1,48 @@
+require 'minitest/autorun'
+require 'pi_piper'
+
+
+def is_raspberry?
+  RUBY_PLATFORM == "arm-linux-eabihf"
+end
+
+describe 'Pi_Piper' do
+  describe "when a pin is created" do
+    it "should restrict allowed :pull values" do
+      proc { PiPiper::Pin.new(:pin => 17, :direction => :in, :pull => :wth) }.must_raise RuntimeError
+      PiPiper::Pin.new(:pin => 17, :direction => :in, :pull => :up).pull?.must_equal :up
+      PiPiper::Pin.new(:pin => 17, :direction => :in, :pull => :down).pull?.must_equal :down
+      PiPiper::Pin.new(:pin => 17, :direction => :in, :pull => :off).pull?.must_equal :off
+      PiPiper::Pin.new(:pin => 17, :direction => :in, :pull => :float).pull?.must_equal :off
+    end
+    it "should not accept pulls when direction is :out" do
+      proc { raise }.must_not_raise RuntimeError
+    end
+    it "should not allow pull! when direction is :out" do
+      proc { raise }.must_not_raise RuntimeError
+    end
+    it "should not allow subsequent pull resistor changes when direction is :out" do
+      true.must_equal false
+    end
+    it "should allow subsequent pull resistor changes when direction is :in" do
+      true.must_equal false
+    end
+  end
+
+  describe "when pull mode is set to up" do
+    @pin = PiPiper::Pin.new(:pin => 17, :direction => :in, :pull => :up)
+    it "must respond HIGH when floating pins are checked" do
+      skip("Pull-up test run only on Raspberry") unless is_raspberry?
+      @pin.on?.must_be true
+    end
+  end
+
+  describe "when pull mode is set to down" do
+    @pin = PiPiper::Pin.new(:pin => 17, :direction => :in, :pull => :down)
+    it "must respond LOW when flaoting pins are checked" do
+      skip("Pull-up test run only on Raspberry") unless is_raspberry?
+      @pin.off?.must_be true
+    end
+  end
+end
+


### PR DESCRIPTION
Added documentation in README.md
Added tests in spec/pull_mode_spec.rb, and rake task to start them
(`rake test`).
Added `echoe` and `rake` as dev deps.
Implemented pulling up/down pin via ffi+bcm lib.
