### PR TITLE
watch function return new thread object for unwatch

### DIFF
--- a/lib/pi_piper.rb
+++ b/lib/pi_piper.rb
@@ -14,7 +14,7 @@ module PiPiper
   #   Options hash. Options include `:pin`, `:invert` and `:trigger`.
   # 
   def watch(options, &block)
-    Thread.new do
+    new_thread = Thread.new do
       pin = PiPiper::Pin.new(options)
       loop do
         pin.wait_for_change 
@@ -24,7 +24,9 @@ module PiPiper
           pin.instance_exec &block
         end
       end 
-    end.abort_on_exception = true  
+    end
+    new_thread.abort_on_exception = true
+    new_thread
   end
   
   #Defines an event block to be executed after a pin either goes high or low.


### PR DESCRIPTION
`watch` function return new thread object so that thread can be killed by code
code like that:

``` ruby
pin_11_thread = watch :pin => 11 do
    puts "I am just be watched"
  end

## unwatch pin 11
pin_11_thread.kill
```

use `kill` method seems not brilliant but I can find another way to write a function like 

``` ruby
unwatch :pin=> 11 ......
```

is this way ok?
