### PR TITLE
Update SPI to use the platform driver

### DIFF
--- a/lib/pi_piper/spi.rb
+++ b/lib/pi_piper/spi.rb
@@ -48,12 +48,18 @@ module PiPiper
     # No CS, control it yourself
     CHIP_SELECT_NONE = 3
 
+    # SPI Modes
+    SPI_MODE0 = 0
+    SPI_MODE1 = 1
+    SPI_MODE2 = 2
+    SPI_MODE3 = 3 
+
     #Sets the SPI mode. Defaults to mode (0,0).
     def self.set_mode(cpol, cpha)
-      mode = Platform.driver::SPI_MODE0 #default
-      mode = Platform.driver::SPI_MODE1 if cpol == 0 and cpha == 1
-      mode = Platform.driver::SPI_MODE2 if cpol == 1 and cpha == 0
-      mode = Platform.driver::SPI_MODE3 if cpol == 1 and cpha == 1
+      mode = SPI_MODE0 #default
+      mode = SPI_MODE1 if cpol == 0 and cpha == 1
+      mode = SPI_MODE2 if cpol == 1 and cpha == 0
+      mode = SPI_MODE3 if cpol == 1 and cpha == 1
       Platform.driver.spi_set_data_mode mode
     end
 

--- a/spec/spi_spec.rb
+++ b/spec/spi_spec.rb
@@ -1,0 +1,37 @@
+require_relative 'spec_helper'
+
+describe 'Spi' do
+
+  describe "when in block" do
+
+    it "should call spi_begin" do
+      driver = StubDriver.new
+      expect(driver).to receive(:spi_begin)
+
+      Platform.driver = driver
+      Spi.begin do
+      end
+    end
+
+    it "should call spi_chip_select to set and unset chip" do
+      driver = StubDriver.new
+      expect(driver).to receive(:spi_chip_select).with(Spi::CHIP_SELECT_1)
+      expect(driver).to receive(:spi_chip_select).with(Spi::CHIP_SELECT_NONE)
+
+      Platform.driver = driver
+      Spi.begin(Spi::CHIP_SELECT_1) do
+	read
+      end
+    end
+  end
+
+  describe "set mode" do
+    it "should call spi_set_data_mode" do
+      driver = StubDriver.new
+      expect(driver).to receive(:spi_set_data_mode).with(Spi::SPI_MODE3)
+
+      Platform.driver = driver
+      Spi.set_mode(1, 1)
+    end
+  end
+end


### PR DESCRIPTION
I was having problems with SPI and found Bcm2835 wasn't being init'ed because the Platform.driver changes weren't applied to SPI. I also tried to add a couple basic SPI spec tests
