### PR TITLE
Move to using (some) bcm2835 functions

### DIFF
--- a/lib/pi_piper/pin_values.rb
+++ b/lib/pi_piper/pin_values.rb
@@ -6,5 +6,15 @@ module PiPiper
 
     GPIO_HIGH = 1
     GPIO_LOW  = 0
+
+    GPIO_FSEL_INPT = 0b000
+    GPIO_FSEL_OUTP = 0b001
+    GPIO_FSEL_ALT0 = 0b100
+    GPIO_FSEL_ALT1 = 0b101
+    GPIO_FSEL_ALT2 = 0b110
+    GPIO_FSEL_ALT3 = 0b111
+    GPIO_FSEL_ALT4 = 0b011
+    GPIO_FSEL_ALT5 = 0b010
+    GPIO_FSEL_MASK = 0b111
   end
 end


### PR DESCRIPTION
I kept getting `@ fptr_finalize - /sys/class/gpio/export (Errno::EBUSY)` after I would kill the ruby script I was writing, so I looked into things a bit and found that we could use the driver directly for setting these functions instead of using the file system.

```
Finished in 0.01079 seconds
46 examples, 0 failures, 4 pending
```