### PR TITLE
Update spec directory to use only rspec3

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--color
+--format documentation
+--require spec_helper

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+
+before_install:
+  - gem install bundler
+  - gem update

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 gem 'echoe'
 gem 'rake'
 gem 'ffi'
-gem "eventmachine", "~> 1.0.3"
+gem "eventmachine", "~> 1.0.9"
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     pi_piper (2.0.beta.11)
-      eventmachine (= 1.0.3)
+      eventmachine (= 1.0.9)
       ffi
 
 GEM
@@ -16,7 +16,7 @@ GEM
       rake (>= 0.9.2)
       rdoc (>= 3.6.1)
       rubyforge (>= 2.0.4)
-    eventmachine (1.0.3)
+    eventmachine (1.0.9)
     ffi (1.9.0)
     gemcutter (0.7.1)
     json (1.8.1)
@@ -28,14 +28,19 @@ GEM
     rake (10.1.0)
     rdoc (4.0.1)
       json (~> 1.4)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.6)
-    rspec-expectations (2.14.3)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.4)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.1)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
     rubyforge (2.0.4)
       json_pure (>= 1.1.7)
     simplecov (0.7.1)
@@ -48,10 +53,13 @@ PLATFORMS
 
 DEPENDENCIES
   echoe
-  eventmachine (~> 1.0.3)
+  eventmachine (~> 1.0.9)
   ffi
   mocha
   pi_piper!
   rake
   rspec
   simplecov
+
+BUNDLED WITH
+   1.11.2

--- a/lib/pi_piper/i2c.rb
+++ b/lib/pi_piper/i2c.rb
@@ -28,7 +28,6 @@ module PiPiper
 
     def self.clock=(clock)
       valid_clocks = Platform.driver.i2c_allowed_clocks
-
       raise "Invalid clock rate. Valid clocks are 100 kHz, 399.3610 kHz, 1.666 MHz and 1.689 MHz" unless valid_clocks.include? clock
 
       Platform.driver.i2c_set_clock clock

--- a/lib/pi_piper/stub_driver.rb
+++ b/lib/pi_piper/stub_driver.rb
@@ -70,7 +70,6 @@ module PiPiper
       @spi[:chip_select] = chip
     end
 
-
     def pin_read(pin_number)
       val = pin(pin_number)[:value]
       val ||= case pin(pin_number)[:pud]
@@ -81,7 +80,7 @@ module PiPiper
     end
 
     def method_missing(meth, *args, &block)
-      puts("Needs Implementation: StubDriver##{meth}")
+      puts "Needs Implementation: StubDriver##{meth}"
     end
 
     private

--- a/pi_piper.gemspec
+++ b/pi_piper.gemspec
@@ -24,14 +24,14 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0')
       s.add_runtime_dependency(%q<ffi>, [">= 0"])
-      s.add_runtime_dependency(%q<eventmachine>, ["= 1.0.3"])
+      s.add_runtime_dependency(%q<eventmachine>, ["= 1.0.9"])
     else
       s.add_dependency(%q<ffi>, [">= 0"])
-      s.add_dependency(%q<eventmachine>, ["= 1.0.3"])
+      s.add_dependency(%q<eventmachine>, ["= 1.0.9"])
     end
   else
     s.add_dependency(%q<ffi>, [">= 0"])
-    s.add_dependency(%q<eventmachine>, ["= 1.0.3"])
+    s.add_dependency(%q<eventmachine>, ["= 1.0.9"])
   end
 
   s.add_development_dependency 'rspec'

--- a/spec/i2c_spec.rb
+++ b/spec/i2c_spec.rb
@@ -1,38 +1,35 @@
 require_relative 'spec_helper'
 
 describe 'I2C' do
-
-  describe "clock setting" do
-
-    it "should check driver settings" do
+  describe 'clock setting' do
+    it 'should check driver settings' do
       Platform.driver = StubDriver.new.tap do |d|
-        d.should_receive(:i2c_allowed_clocks).and_return([100.kilohertz])
+        expect(d).to receive(:i2c_allowed_clocks).and_return([100.kilohertz])
       end
 
       I2C.clock = 100.kilohertz
     end
 
-    it "should accept 100 kHz" do
+    it 'should accept 100 kHz' do
       Platform.driver = StubDriver.new.tap do |d|
-        d.should_receive(:i2c_allowed_clocks).and_return([100.kilohertz])
-        d.should_receive(:i2c_set_clock).with(100.kilohertz)
+        expect(d).to receive(:i2c_allowed_clocks).and_return([100.kilohertz])
+        expect(d).to receive(:i2c_set_clock).with(100.kilohertz)
       end
 
       I2C.clock = 100.kilohertz
     end
 
-    it "should not accept 200 kHz" do
+    it 'should not accept 200 kHz' do
       Platform.driver = StubDriver.new.tap do |d|
-        d.should_receive(:i2c_allowed_clocks).and_return([100.kilohertz])
+        expect(d).to receive(:i2c_allowed_clocks).and_return([100.kilohertz])
       end
 
-      expect { I2C.clock = 200.kilohertz }.to raise_error
+      expect { I2C.clock = 200.kilohertz }.to raise_error(RuntimeError)
     end
   end
 
-  describe "when in block" do
-
-    it "should call i2c_begin" do
+  describe 'when in block' do
+    it 'should call i2c_begin' do
       driver = StubDriver.new
       expect(driver).to receive(:i2c_begin)
 
@@ -41,7 +38,7 @@ describe 'I2C' do
       end
     end
 
-    it "should call i2c_end" do
+    it 'should call i2c_end' do
       driver = StubDriver.new
       expect(driver).to receive(:i2c_end)
 
@@ -50,40 +47,37 @@ describe 'I2C' do
       end
     end
 
-    it "should call i2c_end even after raise" do
+    it 'should call i2c_end even after raise' do
       driver = StubDriver.new
       expect(driver).to receive(:i2c_end)
 
       Platform.driver = driver
       begin
-        I2C.begin { raise "OMG" }
+        I2C.begin { raise 'OMG' }
       rescue
       end
     end
 
-    describe "write operation" do
-
-      it "should set address" do
+    describe 'write operation' do
+      it 'should set address' do
         Platform.driver = StubDriver.new.tap do |d|
-          d.should_receive(:i2c_set_address).with(4)
+          expect(d).to receive(:i2c_set_address).with(4)
         end
 
         I2C.begin do
-          write :to => 4, :data => [1, 2, 3, 4]
+          write to: 4, data: [1, 2, 3, 4]
         end
       end
 
-      it "should pass data to driver" do
+      it 'should pass data to driver' do
         Platform.driver = StubDriver.new.tap do |d|
-          d.should_receive(:i2c_transfer_bytes).with([1, 2, 3, 4])
+          expect(d).to receive(:i2c_transfer_bytes).with([1, 2, 3, 4])
         end
 
         I2C.begin do
-          write :to => 4, :data => [1, 2, 3, 4]
+          write to: 4, data: [1, 2, 3, 4]
         end
       end
-
     end
-
   end
 end

--- a/spec/pin_spec.rb
+++ b/spec/pin_spec.rb
@@ -2,118 +2,118 @@ require 'spec_helper'
 include PiPiper
 
 describe 'Pin' do
-
-  it "should export pin for input" do
+  it 'should export pin for input' do
     Platform.driver = StubDriver.new.tap do |d|
-      d.should_receive(:pin_input).with(4)
+      expect(d).to receive(:pin_input).with(4)
     end
 
-    Pin.new :pin => 4, :direction => :in
+    Pin.new pin: 4, direction: :in
   end
-  
-  it "should export pin for output" do
+
+  it 'should export pin for output' do
     Platform.driver = StubDriver.new.tap do |d|
-      d.should_receive(:pin_output).with(4)
+      expect(d).to receive(:pin_output).with(4)
     end
 
-    Pin.new :pin => 4, :direction => :out
+    Pin.new pin: 4, direction: :out
   end
-  
-  it "should read start value on construction" do
+
+  it 'should read start value on construction' do
     Platform.driver = StubDriver.new.tap do |d|
-      d.should_receive(:pin_read).with(4).and_return(0)
+      expect(d).to receive(:pin_read).with(4).and_return(0)
     end
 
-    Pin.new :pin => 4, :direction => :in
+    Pin.new pin: 4, direction: :in
   end
-  
-  it "should detect on?" do
+
+  it 'should detect on?' do
     Platform.driver = StubDriver.new.tap do |d|
-      d.should_receive(:pin_read).with(4).and_return(1)
+      expect(d).to receive(:pin_read).with(4).and_return(1)
     end
 
-    pin = Pin.new :pin => 4, :direction => :in
-    pin.on?.should == true
+    pin = Pin.new pin: 4, direction: :in
+    expect(pin.on?).to be(true)
   end
-  
-  it "should detect off?" do
+
+  it 'should detect off?' do
     Platform.driver = StubDriver.new.tap do |d|
-      d.should_receive(:pin_read).with(4).and_return(0)
+      expect(d).to receive(:pin_read).with(4).and_return(0)
     end
 
-    pin = Pin.new :pin => 4, :direction => :in
-    pin.off?.should == true
+    pin = Pin.new pin: 4, direction: :in
+    expect(pin.off?).to be(true)
   end
-  
-  it "should invert true" do
+
+  it 'should invert true' do
     Platform.driver = StubDriver.new.tap do |d|
-      d.should_receive(:pin_read).with(4).and_return(1)
+      expect(d).to receive(:pin_read).with(4).and_return(1)
     end
 
-    pin = Pin.new :pin => 4, :direction => :in, :invert => true
-    pin.on?.should == false    
+    pin = Pin.new pin: 4, direction: :in, invert: true
+    expect(pin.on?).to be(false)
   end
-  
-  it "should invert true" do
+
+  it 'should invert true' do
     Platform.driver = StubDriver.new.tap do |d|
-      d.should_receive(:pin_read).with(4).and_return(0)
+      expect(d).to receive(:pin_read).with(4).and_return(0)
     end
 
-    pin = Pin.new :pin => 4, :direction => :in, :invert => true
-    pin.off?.should == false    
-  end  
-  
-  it "should write high" do
+    pin = Pin.new pin: 4, direction: :in, invert: true
+    expect(pin.off?).to be(false)
+  end
+
+  it 'should write high' do
     Platform.driver = StubDriver.new.tap do |d|
-      d.should_receive(:pin_set).with(4, 1)
+      expect(d).to receive(:pin_set).with(4, 1)
     end
 
-    pin = Pin.new :pin => 4, :direction => :out
+    pin = Pin.new pin: 4, direction: :out
     pin.on
   end
-  
-  it "should write low" do
+
+  it 'should write low' do
     Platform.driver = StubDriver.new.tap do |d|
-      d.should_receive(:pin_set).with(4, 0)
+      expect(d).to receive(:pin_set).with(4, 0)
     end
 
-    pin = Pin.new :pin => 4, :direction => :out
+    pin = Pin.new pin: 4, direction: :out
     pin.off
   end
-  
-  it "shouldn't write high on direction in" do
+
+  it 'should not write high on direction in' do
     Platform.driver = StubDriver.new.tap do |d|
-      d.stub(:pin_set) { fail }
+      expect(d).not_to receive(:pin_set)
     end
 
-    pin = Pin.new :pin => 4, :direction => :in
-    pin.on    
+    pin = Pin.new pin: 4, direction: :in
+    pin.on
   end
-  
-  it "shouldn't write low on direction in" do
+
+  it 'should not write low on direction in' do
     Platform.driver = StubDriver.new.tap do |d|
-      d.stub(:pin_set) { fail }
+      expect(d).not_to receive(:pin_set)
     end
 
-    pin = Pin.new :pin => 4, :direction => :in
-    pin.off    
+    pin = Pin.new pin: 4, direction: :in
+    pin.off
   end
-  
-  it "should detect high to low change" do
+
+  it 'should detect high to low change' do
     Platform.driver = StubDriver.new.tap do |d|
       value = 1
-      d.stub(:pin_read) { value ^= 1 } #begins low, then high, low, high, low...
+      # begins low, then high, low, high, low...
+      allow(d).to receive(:pin_read) { value ^= 1 }
     end
 
-    pin = Pin.new :pin => 4, :direction => :in
-    pin.off?.should == true
+    pin = Pin.new pin: 4, direction: :in
+    expect(pin.off?).to be(true)
     pin.read
-    pin.off?.should == false
-    pin.changed?.should == true
+    expect(pin.off?).to be(false)
+    expect(pin.changed?).to be(true)
   end
   
-  #it "should wait for change" do
-  #  fail
-  #end
+  xit 'should wait for change' do
+    pending
+  end
 
 end

--- a/spec/pull_mode_spec.rb
+++ b/spec/pull_mode_spec.rb
@@ -1,53 +1,70 @@
 require_relative 'spec_helper'
 
 describe 'Pi_Piper' do
-  Platform.driver = StubDriver.new
-  describe "when a pin is created" do
+  before (:each) do
+    Platform.driver = StubDriver.new
+  end
 
-    it "should restrict allowed :pull values" do
-      proc { PiPiper::Pin.new(:pin => 17, :direction => :in, :pull => :wth) }.should raise_exception(RuntimeError)
+  let(:pin_up) do
+    PiPiper::Pin.new(pin: 17, direction: :in, pull: :up)
+  end
+  let(:pin_down) do
+    PiPiper::Pin.new(pin: 17, direction: :in, pull: :down)
+  end
+  let(:pin_off) do
+    PiPiper::Pin.new(pin: 17, direction: :in, pull: :off)
+  end
+  let(:pin_float) do
+    PiPiper::Pin.new(pin: 17, direction: :in, pull: :float)
+  end
 
-      PiPiper::Pin.new(:pin => 17, :direction => :in, :pull => :up).pull?.should eql(:up)
-      PiPiper::Pin.new(:pin => 17, :direction => :in, :pull => :down).pull?.should eql(:down)
-      PiPiper::Pin.new(:pin => 17, :direction => :in, :pull => :off).pull?.should eql(:off)
-      PiPiper::Pin.new(:pin => 17, :direction => :in, :pull => :float).pull?.should eql(:off)
+  describe 'when a pin is created' do
+    it 'should raise an error for invalid :pull values' do
+      expect { PiPiper::Pin.new(pin: 17, direction: :in, pull: :wth) }.to(
+        raise_error(RuntimeError))
     end
 
-    xit "should not accept pulls when direction is :out" do
-      proc { raise }.should_not raise_exception(RuntimeError)
+    it 'should restrict allowed :pull values' do
+      expect(pin_up.pull?).to eq(:up)
+      expect(pin_down.pull?).to eq(:down)
+      expect(pin_off.pull?).to eq(:off)
+      expect(pin_float.pull?).to eq(:off)
     end
 
-    xit "should not allow pull! when direction is :out" do
-      proc { raise }.should_not raise_exception(RuntimeError)
+    xit 'should not accept pulls when direction is :out' do
+       expect{ raise }.not_to raise_error(RuntimeError)
     end
 
-    xit "should not allow subsequent pull resistor changes when direction is :out" do
-      true.must_equal false
+    xit 'should not allow pull! when direction is :out' do
+      expect{ raise }.not_to raise_error(RuntimeError)
     end
 
-    xit "should allow subsequent pull resistor changes when direction is :in" do
-      true.must_equal false
+    xit 'should not allow subsequent pull resistor changes when direction is :out' do
+      expect(true).to eq(false)
+    end
+
+    xit 'should allow subsequent pull resistor changes when direction is :in' do
+      expect(true).to eq(false)
     end
   end
 
-  describe "when pull mode is set to up" do
+  describe 'when pull mode is set to up' do
     before :each do
-      @pin = PiPiper::Pin.new(:pin => 17, :direction => :in, :pull => :up)
+      @pin = pin_up
     end
 
-    it "must respond HIGH when floating pins are checked" do
-      @pin.on?.should be_true
+    it 'must respond HIGH when floating pins are checked' do
+      expect(@pin.on?).to be(true)
     end
   end
 
-  describe "when pull mode is set to down" do
+  describe 'when pull mode is set to down' do
     before :each do
-      @pin = PiPiper::Pin.new(:pin => 17, :direction => :in, :pull => :down)
+      @pin = pin_down
     end
 
     it 'must respond LOW when floating pins are checked' do
-      @pin.off?.should be_true
+      expect(@pin.off?).to be(true)
     end
   end
 end
-

--- a/spec/spi_spec.rb
+++ b/spec/spi_spec.rb
@@ -1,10 +1,8 @@
 require_relative 'spec_helper'
 
 describe 'Spi' do
-
-  describe "when in block" do
-
-    it "should call spi_begin" do
+  describe 'when in block' do
+    it 'should call spi_begin' do
       driver = StubDriver.new
       expect(driver).to receive(:spi_begin)
 
@@ -13,20 +11,20 @@ describe 'Spi' do
       end
     end
 
-    it "should call spi_chip_select to set and unset chip" do
+    it 'should call spi_chip_select to set and unset chip' do
       driver = StubDriver.new
       expect(driver).to receive(:spi_chip_select).with(Spi::CHIP_SELECT_1)
       expect(driver).to receive(:spi_chip_select).with(Spi::CHIP_SELECT_NONE)
 
       Platform.driver = driver
       Spi.begin(Spi::CHIP_SELECT_1) do
-	read
+        read
       end
     end
   end
 
-  describe "set mode" do
-    it "should call spi_set_data_mode" do
+  describe 'set mode' do
+    it 'should call spi_set_data_mode' do
       driver = StubDriver.new
       expect(driver).to receive(:spi_set_data_mode).with(Spi::SPI_MODE3)
 
@@ -38,9 +36,9 @@ describe 'Spi' do
   describe '#spidev_out' do
     it 'should attempt to write data to spi' do
       driver = StubDriver.new
-      expect(driver).to receive(:spidev_out).with([0,1,2,3,4,5])
+      expect(driver).to receive(:spidev_out).with([0, 1, 2, 3, 4, 5])
       Platform.driver = driver
-      Spi.spidev_out([0,1,2,3,4,5])
+      Spi.spidev_out([0, 1, 2, 3, 4, 5])
     end
   end
 end

--- a/spec/stub_driver_spec.rb
+++ b/spec/stub_driver_spec.rb
@@ -1,109 +1,102 @@
 require 'spec_helper'
 
 describe StubDriver do
-
-  let(:stub_driver){StubDriver.new()}
+  let(:stub_driver) { StubDriver.new }
 
   before do
-    @logger = double()
-    @driver = StubDriver.new(:logger => @logger)
+    @logger = double
+    @driver = StubDriver.new(logger: @logger)
   end
 
   describe '#pin_input' do
-
     it 'should set pin as input' do
       stub_driver.pin_input(10)
-      stub_driver.pin_direction(10).should == :in
+      expect(stub_driver.pin_direction(10)).to eq(:in)
     end
 
     it 'should log that pin is set' do
-      @logger.expects(:debug).with('Pin #10 -> Input')
+      expect(@logger).to receive(:debug).with('Pin #10 -> Input')
       @driver.pin_input(10)
     end
-
   end
 
   describe '#pin_output' do
-
     it 'should set pin as output' do
       stub_driver.pin_output(10)
-      stub_driver.pin_direction(10).should == :out
+      expect(stub_driver.pin_direction(10)).to eq(:out)
     end
 
     it 'should log that pin is set' do
-      @logger.expects(:debug).with('Pin #10 -> Output')
+      expect(@logger).to receive(:debug).with('Pin #10 -> Output')
       @driver.pin_output(10)
     end
-
   end
 
   describe '#pin_set' do
-
     it 'should set pin value' do
       stub_driver.pin_set(22, 42)
-      stub_driver.pin_read(22).should == 42
+      expect(stub_driver.pin_read(22)).to eq(42)
     end
 
     it 'should log the new pin value' do
-      @logger.expects(:debug).with('Pin #21 -> 22')
+      expect(@logger).to receive(:debug).with('Pin #21 -> 22')
       @driver.pin_set(21, 22)
     end
-
   end
 
   describe '#pin_set_pud' do
     it 'should set pin value' do
       stub_driver.pin_set_pud(12, Pin::GPIO_PUD_UP)
-      stub_driver.pin_read(12).should == Pin::GPIO_HIGH
+      expect(stub_driver.pin_read(12)).to eq(Pin::GPIO_HIGH)
     end
 
     it 'should not overwrite set value' do
-      stub_driver.pin_set(12,0)
+      stub_driver.pin_set(12, 0)
       stub_driver.pin_set_pud(12, Pin::GPIO_PUD_DOWN)
-      stub_driver.pin_read(12).should == Pin::GPIO_LOW
+      expect(stub_driver.pin_read(12)).to eq(Pin::GPIO_LOW)
     end
 
     it 'should log the new pin value' do
-      @logger.expects(:debug).with('PinPUD #21 -> 22')
+      expect(@logger).to receive(:debug).with('PinPUD #21 -> 22')
       @driver.pin_set_pud(21, 22)
     end
   end
 
   describe '#spidev_out' do
-    it "should log the array sent to ada_spi_out" do
-      @logger.expects(:debug).with("SPIDEV -> \u0000\u0001\u0002")
-      @driver.spidev_out([0x00,0x01,0x02])
+    it 'should log the array sent to ada_spi_out' do
+      expect(@logger).to receive(:debug).with("SPIDEV -> \u0000\u0001\u0002")
+      @driver.spidev_out([0x00, 0x01, 0x02])
     end
   end
 
   describe '#spi_begin' do
     it 'should should clear spi data' do
-      @logger.expects(:debug)
-      @driver.spi_transfer_bytes([0x01,0x02])
-      @logger.expects(:debug).with("SPI Begin")
+      expect(@logger).to receive(:debug)
+      @driver.spi_transfer_bytes([0x01, 0x02])
+      expect(@logger).to receive(:debug).with('SPI Begin')
       @driver.spi_begin
-      @driver.send(:spi_data).should == []
+      expect(@driver.send(:spi_data)).to eq([])
     end
   end
 
   describe '#spi_transfer_bytes' do
     it 'should log and store sent data' do
-      @logger.expects(:debug).with("SPI CS0 <- [1, 2, 3]")
+      expect(@logger).to receive(:debug).with('SPI CS0 <- [1, 2, 3]')
       @driver.spi_transfer_bytes([0x01, 0x02, 0x03])
-      @driver.send(:spi_data).should == [0x01, 0x02, 0x03]
+      expect(@driver.send(:spi_data)).to eq([0x01, 0x02, 0x03])
     end
   end
 
   describe '#spi_chip_select' do
     it 'should return default 0 if nothing provided' do
-      @logger.expects(:debug).with("SPI Chip Select = 0")
-      @driver.spi_chip_select.should == 0
+      expect(@logger).to receive(:debug).with('SPI Chip Select = 0')
+      expect(@driver.spi_chip_select).to eq(0)
     end
 
     it 'should set chip select value if passed in' do
-      @logger.expects(:debug).with("SPI Chip Select = 3").twice
+      expect(@logger).to receive(:debug).with('SPI Chip Select = 3').twice
       @driver.spi_chip_select(3)
-      @driver.spi_chip_select.should == 3
+      expect(@driver.spi_chip_select).to eq(3)
     end
   end
 
@@ -112,9 +105,9 @@ describe StubDriver do
     it 'should not reset unless asked' do
       StubDriver.new()
       StubDriver.pin_set(1,3)
-      StubDriver.pin_read(1).should == 3
+      expect(StubDriver.pin_read(1)).to eq(3)
       StubDriver.reset
-      StubDriver.pin_read(1).should be_nil
+      expect(StubDriver.pin_read(1)).to be_nil
     end
   end
 


### PR DESCRIPTION
- Upgrade rspec to rspec 3
- Rework all tests to rspec 3 format
- Made a minor upgrade to eventmachine
- Added `.rspec` to make rspec output cleaner
- Fixed some rubocop issues along the way under the spec directory

I saw the tests were mixed between `rspec2` and `rspec3`. Took a stab at migrating all tests to use rspec3 and got rspec to stop showing the deprecation warnings by removing all the rspec2 code. I ran rubocop as I was working on it and fixed issues within the spec directory as I made the changes. There are a lot of changes, so heads up :smile: 