### PR TITLE
Release pin

### DIFF
--- a/lib/pi_piper/bcm2835.rb
+++ b/lib/pi_piper/bcm2835.rb
@@ -6,6 +6,7 @@ module PiPiper
   module Bcm2835
     extend FFI::Library
     ffi_lib File.dirname(__FILE__) + '/libbcm2835.so'
+    @pins = []
 
     SPI_MODE0 = 0
     SPI_MODE1 = 1
@@ -19,26 +20,47 @@ module PiPiper
 
     attach_function :init, :bcm2835_init, [], :uint8
     attach_function :close, :bcm2835_close, [], :uint8
-    
+
     #pin support...
-    attach_function :pin_set_pud,         :bcm2835_gpio_set_pud,     [:uint8, :uint8], :void
+    attach_function :pin_set_pud, :bcm2835_gpio_set_pud, [:uint8, :uint8], :void
     
     def self.pin_input(pin)
-      File.open("/sys/class/gpio/export", "w") { |f| f.write("#{pin}") }
-      File.open("/sys/class/gpio/gpio#{pin}/direction", "w") { |f| f.write("in") }
+      export(pin)
+      pin_direction(pin, 'in')
     end
-    
+
     def self.pin_set(pin, value)
       File.open("/sys/class/gpio/gpio#{pin}/value", 'w') {|f| f.write("#{value}") }
     end
-    
+
     def self.pin_output(pin)
-      File.open("/sys/class/gpio/export", "w") { |f| f.write("#{pin}") }
-      File.open("/sys/class/gpio/gpio#{pin}/direction", "w") { |f| f.write("out") }
+      export(pin)
+      pin_direction(pin, 'out')
     end
-    
+
     def self.pin_read(pin)
       File.read("/sys/class/gpio/gpio#{pin}/value").to_i
+    end
+
+    def self.pin_direction(pin, direction)
+      File.open("/sys/class/gpio/gpio#{pin}/direction", 'w') do |f|
+        f.write(direction)
+      end
+    end
+
+    # Exports pin and subsequently locks it from outside access
+    def self.export(pin)
+      File.open('/sys/class/gpio/export', 'w') { |f| f.write("#{pin}") }
+      @pins << pin unless @pins.include?(pin)
+    end
+
+    def self.release_pin(pin)
+      File.open('/sys/class/gpio/unexport', 'w') { |f| f.write("#{pin}") }
+      @pins.delete(pin)
+    end
+
+    def self.release_pins
+      @pins.dup.each { |pin| release_pin(pin) }
     end
 
     #NOTE to use: chmod 666 /dev/spidev0.0
@@ -70,11 +92,11 @@ module PiPiper
       [100.kilohertz,
        399.3610.kilohertz,
        1.666.megahertz,
-       1.689.megahertz]      
+       1.689.megahertz]
     end
 
     def self.spi_transfer_bytes(data)
-      data_out = FFI::MemoryPointer.new(data.count) 
+      data_out = FFI::MemoryPointer.new(data.count)
       data_in = FFI::MemoryPointer.new(data.count)
       (0..data.count-1).each { |i| data_out.put_uint8(i, data[i]) }
 
@@ -96,6 +118,5 @@ module PiPiper
 
       (0..bytes-1).map { |i| data_in.get_uint8(i) } 
     end
-
   end
 end

--- a/lib/pi_piper/pin_error.rb
+++ b/lib/pi_piper/pin_error.rb
@@ -1,0 +1,3 @@
+module PiPiper
+  class PinError < StandardError; end
+end

--- a/lib/pi_piper/platform.rb
+++ b/lib/pi_piper/platform.rb
@@ -10,7 +10,10 @@ module PiPiper
         require 'pi_piper/bcm2835'
         PiPiper::Bcm2835.init
         @@driver = PiPiper::Bcm2835
-        at_exit { Bcm2835.close }
+        at_exit do
+          Bcm2835.release_pins
+          Bcm2835.close
+        end
       end
       @@driver
     end
@@ -18,7 +21,5 @@ module PiPiper
     def self.driver=(instance)
       @@driver = instance
     end
-
   end
-
 end

--- a/lib/pi_piper/stub_driver.rb
+++ b/lib/pi_piper/stub_driver.rb
@@ -26,11 +26,13 @@ module PiPiper
     alias_method :reset, :new
 
     def pin_input(pin_number)
+      #@pins[pin_number] = { direction: :in }
       pin(pin_number)[:direction] = :in
       @logger.debug("Pin ##{pin_number} -> Input")
     end
 
     def pin_output(pin_number)
+      #@pins[pin_number] = { direction: :in }
       pin(pin_number)[:direction] = :out
       @logger.debug("Pin ##{pin_number} -> Output")
     end
@@ -79,20 +81,27 @@ module PiPiper
               end
     end
 
+    def release_pins
+      @pins.keys.each { |pin_number| release_pin(pin_number) }
+    end
+
+    def release_pin(pin_number)
+      @pins.delete(pin_number)
+    end
+
     def method_missing(meth, *args, &block)
       puts "Needs Implementation: StubDriver##{meth}"
     end
 
     private
 
-      def pin(pin_number)
-        @pins[pin_number] || (@pins[pin_number] = {})
-      end
+    def pin(pin_number)
+      @pins[pin_number] ||= {}
+    end
 
     ## The following methods are only for testing and are not available on any platforms
-      def spi_data
-        @spi[:data]
-      end
-
+    def spi_data
+      @spi[:data]
+    end   
   end
 end

--- a/lib/pi_piper/version.rb
+++ b/lib/pi_piper/version.rb
@@ -1,0 +1,3 @@
+module PiPiper
+  VERSION = '1.9.9'
+end

--- a/pi_piper.gemspec
+++ b/pi_piper.gemspec
@@ -1,15 +1,18 @@
-# -*- encoding: utf-8 -*-
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'pi_piper/version'
 
 Gem::Specification.new do |s|
   s.name = "pi_piper"
-  s.version = "2.0.beta.11"
+  s.version = PiPiper::VERSION
 
   s.required_rubygems_version = Gem::Requirement.new(">= 1.2") if s.respond_to? :required_rubygems_version=
   s.authors = ["Jason Whitehorn"]
   s.date = "2013-09-14"
   s.description = "Event driven Raspberry Pi GPIO library"
   s.email = "jason.whitehorn@gmail.com"
-  s.extra_rdoc_files = ["README.md", "lib/pi_piper.rb", "lib/pi_piper/bcm2835.rb", "lib/pi_piper/frequency.rb", "lib/pi_piper/i2c.rb", "lib/pi_piper/libbcm2835.img", "lib/pi_piper/pin.rb", "lib/pi_piper/platform.rb", "lib/pi_piper/spi.rb"]
+  s.extra_rdoc_files = ["README.md", "lib/pi_piper.rb", "lib/pi_piper/bcm2835.rb", "lib/pi_piper/frequency.rb", "lib/pi_piper/i2c.rb", "lib/pi_piper/libbcm2835.so", "lib/pi_piper/pin.rb", "lib/pi_piper/platform.rb", "lib/pi_piper/spi.rb"]
   s.files         = `git ls-files -z`.split("\x0")
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.homepage = "http://github.com/jwhitehorn/pi_piper"

--- a/spec/pin_spec.rb
+++ b/spec/pin_spec.rb
@@ -6,7 +6,6 @@ describe 'Pin' do
     Platform.driver = StubDriver.new.tap do |d|
       expect(d).to receive(:pin_input).with(4)
     end
-
     Pin.new pin: 4, direction: :in
   end
 
@@ -111,9 +110,40 @@ describe 'Pin' do
     expect(pin.off?).to be(false)
     expect(pin.changed?).to be(true)
   end
-  
+
   xit 'should wait for change' do
     pending
   end
 
+  context 'given a pin is released' do
+    it 'should actually release it' do
+      Platform.driver = StubDriver.new.tap do |driver|
+        expect(driver).to receive(:release_pin).with(4)
+      end
+   
+      pin = Pin.new(pin: 4, direction: :in)
+      pin.release
+      expect(pin.released?).to be(true)
+    end
+
+    it 'should not mark unreleased pins as released' do
+      pin = Pin.new(pin: 4, direction: :in)
+      expect(pin.released?).to be(false)
+    end
+
+    it 'should not continue to use the pin' do
+      Platform.driver = StubDriver.new.tap do |driver|
+        expect(driver).to receive(:release_pin).with(4)
+      end
+
+      pin = Pin.new(pin: 4, direction: :in)
+      pin.release
+
+      expect { pin.read }.to raise_error(PinError, 'Pin 4 already released')
+      expect { pin.on }.to raise_error(PinError, 'Pin 4 already released')
+      expect { pin.off }.to raise_error(PinError, 'Pin 4 already released')
+      expect { pin.pull!(:up) }.to(
+        raise_error(PinError, 'Pin 4 already released'))
+    end
+  end
 end

--- a/spec/stub_driver_spec.rb
+++ b/spec/stub_driver_spec.rb
@@ -100,7 +100,6 @@ describe StubDriver do
     end
   end
 
-
   describe '#reset' do
     it 'should not reset unless asked' do
       StubDriver.new()
@@ -111,4 +110,31 @@ describe StubDriver do
     end
   end
 
+  describe '#release_pins' do
+    before(:each) do
+      StubDriver.new
+      StubDriver.pin_input(4)
+      StubDriver.pin_output(6)
+    end
+
+    it 'should keep track of open pins and release them' do
+      expect(@driver).to receive(:release_pin).with(4)
+      expect(@driver).to receive(:release_pin).with(6)
+
+      StubDriver.release_pins
+    end
+
+    it 'should remove released pins' do
+      StubDriver.release_pins
+
+      expect(StubDriver.pin_direction(4)).to be_nil
+      expect(StubDriver.pin_direction(6)).to be_nil
+    end
+
+    it 'should keep track of released pins' do
+      StubDriver.release_pins
+      expect(@driver).not_to receive(:release_pin)
+      StubDriver.release_pins
+    end
+  end
 end


### PR DESCRIPTION
Not to steal anyone's thunder, but this was heavily inspired by the following PR: https://github.com/jwhitehorn/pi_piper/pull/32

- Added tests for `StubDriver` and `Pin`
- Added a new error class `PinError`
- Added `release_pin(pin)` and `release_pins` on `driver`
- Added `release` on `Pin`
- Added `released?` on `Pin`
- Bumped up the version to `2.0.0` so we can release this change and some changes currently in dev
- Fixed a missing `gemspec` update from this PR: https://github.com/jwhitehorn/pi_piper/pull/49

### Manual Pin Release
If one needs to, they can release a pin manually by calling `pin.release`. This will prevent that object from accessing the pin anymore. Creating a new pin via `Pin.new` will be needed if access is needed to that pin again.

```ruby
pin = Pin.new(pin: 4, :direction: :in)
pin.released? # -> false
pin.release
# pin 4 is no longer accessible from the pin object
pin.released? # -> true

pin.read # -> will raise PinError
pin.on # -> will raise PinError
pin.off # -> will raise PinError

pin = Pin.new(pin: 4, :direction: :out)
# pin can now access pin 4 again
```

### Automatic Pin Release
At the end of the program, `Platform.driver.release_pins` is automatically called from the `bcm2835` module. This will release all pins that were accessed in the program. No code change is necessary for anyone using this version of `PiPiper`.
