### PR TITLE
Add i2c LCD driver

### DIFF
--- a/lib/pi_piper.rb
+++ b/lib/pi_piper.rb
@@ -8,15 +8,17 @@ require 'pi_piper/pin'
 require 'pi_piper/spi'
 require 'pi_piper/pwm'
 
+require 'pi_piper/device_drivers/lcd16022004'
+
 module PiPiper
   extend self
 
   #Defines an event block to be executed when an pin event occurs.
   #
-  # @param [PiPiper::Driver] a PiPiper::Driver subclass to load 
+  # @param [PiPiper::Driver] a PiPiper::Driver subclass to load
   # and use with all PiPiper objects.
-  # 
-  def driver=(klass) 
+  #
+  def driver=(klass)
     if !klass.nil? && (klass <= PiPiper::Driver)
       @driver.close if @driver
       @driver = klass.new
@@ -32,29 +34,29 @@ module PiPiper
   end
 
   at_exit { driver.close }
-  
+
   #Defines an event block to be executed when an pin event occurs.
   #
   # == Parameters:
   # options:
   #   Options hash. Options include `:pin`, `:invert` and `:trigger`.
-  # 
+  #
   def watch(options, &block)
     new_thread = Thread.new do
       pin = PiPiper::Pin.new(options)
       loop do
-        pin.wait_for_change 
+        pin.wait_for_change
         if block.arity > 0
           block.call pin
         else
           pin.instance_exec &block
         end
-      end 
+      end
     end
     new_thread.abort_on_exception = true
     new_thread
   end
-  
+
   #Defines an event block to be executed after a pin either goes high or low.
   #
   # @param [Hash] options A hash of options
@@ -64,13 +66,13 @@ module PiPiper
     options[:trigger] = options.delete(:goes) == :high ? :rising : :falling
     watch options, &block
   end
-  
+
   #Defines an event block to be called on a regular schedule. The block will be passed the slave output.
   #
   # @param [Hash] options A hash of options.
   # @option options [Fixnum] :every A frequency of time (in seconds) to poll the SPI slave.
   # @option options [Fixnum] :slave The slave number to poll.
-  # @option options [Number|Array] :write Data to poll the SPI slave with. 
+  # @option options [Number|Array] :write Data to poll the SPI slave with.
   def poll_spi(options, &block)
     EM::PeriodicTimer.new(options[:every]) do
       Spi.begin options[:slave] do
@@ -79,20 +81,20 @@ module PiPiper
       end
     end
   end
-  
-  #Defines an event block to be called when SPI slave output meets certain characteristics. 
+
+  #Defines an event block to be called when SPI slave output meets certain characteristics.
   #The block will be passed the slave output.
   #
   # @param [Hash] options A hash of options.
   # @option options [Fixnum] :every A frequency of time (in seconds) to poll the SPI slave.
   # @option options [Fixnum] :slave The slave number to poll.
-  # @option options [Number|Array] :write Data to poll the SPI slave with. 
+  # @option options [Number|Array] :write Data to poll the SPI slave with.
   # @option options [Fixnum] :eq Tests for SPI slave output equality.
   # @option options [Fixnum] :lt Tests for SPI slave output less than supplied value.
   # @option options [Fixnum] :gt Tests for SPI slave output greater than supplied value.
   def when_spi(options, &block)
     poll_spi options do |value|
-      if (options[:eq] && value == options[:eq]) || 
+      if (options[:eq] && value == options[:eq]) ||
          (options[:lt] && value < options[:lt])  ||
          (options[:gt] && value > options[:gt])
           block.call value

--- a/lib/pi_piper/device_drivers/lcd16022004.rb
+++ b/lib/pi_piper/device_drivers/lcd16022004.rb
@@ -1,0 +1,134 @@
+module PiPiper
+  module DeviceDrivers
+    # The LCD 1602 2004 is widely used i2c adapter for LCD displays.
+    # Often there are prepacked LCD displays with this adapter already
+    # soldered on.
+    #
+    # Example:
+    # # Initialize display at I2C address 0x3f
+    # lcd = PiPiper::DeviceDrivers::Lcd16022004.new(0x3f)
+    # # Turn on the backlight
+    # lcd.set_backlight(true)
+    # # Write some text to the first line
+    # lcd.write_text("Hello world", 1)
+
+    class Lcd16022004
+      # Commands
+      CMD_CLEARDISPLAY = 0x01
+      CMD_RETURNHOME = 0x02
+      CMD_ENTRYMODESET = 0x04
+      CMD_DISPLAYCONTROL = 0x08
+      CMD_CURSORSHIFT = 0x10
+      CMD_FUNCTIONSET = 0x20
+      CMD_SETCGRAMADDR = 0x40
+      CMD_SETDDRAMADDR = 0x80
+
+      # Flags for display entry mode
+      ENTRYMODE_ENTRYRIGHT = 0x00
+      ENTRYMODE_ENTRYLEFT = 0x02
+      ENTRYMODE_ENTRYSHIFTINCREMENT = 0x01
+      ENTRYMODE_ENTRYSHIFTDECREMENT = 0x00
+
+      # Flags for display on/off control
+      DISPLAYCONTROL_DISPLAYON = 0x04
+      DISPLAYCONTROL_DISPLAYOFF = 0x00
+      DISPLAYCONTROL_CURSORON = 0x02
+      DISPLAYCONTROL_CURSOROFF = 0x00
+      DISPLAYCONTROL_BLINKON = 0x01
+      DISPLAYCONTROL_BLINKOFF = 0x00
+
+      # Flags for display/cursor shift
+      LCD_DISPLAYMOVE = 0x08
+      LCD_CURSORMOVE = 0x00
+      LCD_MOVERIGHT = 0x04
+      LCD_MOVELEFT = 0x00
+
+      # Flags for function set
+      LCD_8BITMODE = 0x10
+      LCD_4BITMODE = 0x00
+      LCD_2LINE = 0x08
+      LCD_1LINE = 0x00
+      LCD_5x10DOTS = 0x04
+      LCD_5x8DOTS = 0x00
+
+      # Flags for backlight control
+      LCD_BACKLIGHT = 0x08
+      LCD_NOBACKLIGHT = 0x00
+
+      # Row selectors
+      ROW_SELECTOR = [0x80, 0xC0, 0x94, 0xD4]
+
+      # Control bits
+      ENABLE = 0b00000100
+      READWRITE= 0b00000010
+      REGISTER_SELECT = 0b00000001
+
+      def initialize(i2c_address, options = {})
+        @i2c_address = i2c_address
+
+        dots_per_character = case options[:dots_per_character]
+        when nil
+        when :"5x8"
+          LCD_5x8DOTS
+        when :"5x10"
+          LCD_5x10DOTS
+        end
+
+        send_command(0x03)
+        send_command(0x03)
+        send_command(0x03)
+        send_command(0x02)
+
+        send_command(CMD_FUNCTIONSET | LCD_2LINE | dots_per_character | LCD_4BITMODE)
+        send_command(CMD_DISPLAYCONTROL | DISPLAYCONTROL_DISPLAYON)
+        send_command(CMD_CLEARDISPLAY)
+        send_command(CMD_ENTRYMODESET | ENTRYMODE_ENTRYLEFT)
+        sleep(0.2)
+      end
+
+      def strobe(data)
+        I2C.begin do
+          write(data: [data | ENABLE | LCD_BACKLIGHT], to: @i2c_address)
+          sleep(0.0005)
+          write(data: [((data & ~ENABLE) | LCD_BACKLIGHT)], to: @i2c_address)
+          sleep(0.0001)
+        end
+      end
+
+      def write_four_bits(data)
+        I2C.begin do
+          write(data: [data | LCD_BACKLIGHT], to: @i2c_address)
+        end
+        strobe(data)
+      end
+
+      def send_command(cmd, mode = 0)
+        write_four_bits(mode | (cmd & 0xF0))
+        write_four_bits(mode | ((cmd << 4) & 0xF0))
+      end
+
+      def set_backlight(on)
+        I2C.begin do
+          write(data: [on ? LCD_BACKLIGHT : LCD_NOBACKLIGHT], to: @i2c_address)
+        end
+      end
+
+      def clear()
+        send_command(CMD_CLEARDISPLAY)
+        send_command(CMD_RETURNHOME)
+      end
+
+      def write_text(text, row_number)
+        if 1..4.include?(row_number)
+          send_command(ROW_SELECTOR[row_number - 1])
+          text.each_byte do |byte|
+            send_command(byte, REGISTER_SELECT)
+          end
+          true
+        else
+          false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I have ordered some i2c displays on aliexpress and noticed that there quite some code to write to have it working ootb, so I put up an "i2c device driver" up.

I got this working inline, though I kind of blindly integrated the code into the gem.

I'd have to check what the chip reads to add some documentation, too. But it seems to be quite common:
https://de.aliexpress.com/item/Module-For-Arduino-1602-Blue-Backlight-LCD-Display-16x2-HD44780-Character-LCD-IIC-I2C-W-Serial/32616801213.html?spm=2114.13010608.0.0.4Ft3Tc